### PR TITLE
Official dump for beman.dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # beman.dump: A tool for dumping an object's value to standard output
 
-<img src="https://github.com/bemanproject/beman/blob/f5eedad83c135d9ecff22f465e99800b5965d2ce/docs/img/logo-beman-library-dropped.png" style="width:10%; height:auto;">  ![Continuous Integration Tests](https://github.com/bemanproject/dump/actions/workflows/ci_tests.yml/badge.svg)
+<img src="https://github.com/bemanproject/beman/blob/f5eedad83c135d9ecff22f465e99800b5965d2ce/docs/img/logo-beman-library-dropped.png" style="width:5%; height:auto;">  ![Continuous Integration Tests](https://github.com/bemanproject/dump/actions/workflows/ci_tests.yml/badge.svg)
 
 `beman::dump::dump()` prints its arguments space-separated with a new-line. This
 is useful as a debugging utility.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # beman.dump: A tool for dumping an object's value to standard output
 
-![Continuous Integration Tests](https://github.com/bemanproject/dump/actions/workflows/ci_tests.yml/badge.svg)
+<img src="https://github.com/bemanproject/beman/blob/f5eedad83c135d9ecff22f465e99800b5965d2ce/docs/img/logo-beman-library-dropped.png" style="width:10%; height:auto;">  ![Continuous Integration Tests](https://github.com/bemanproject/dump/actions/workflows/ci_tests.yml/badge.svg)
 
 `beman::dump::dump()` prints its arguments space-separated with a new-line. This
 is useful as a debugging utility.
 A call to `beman::dump::dump(arg1, arg2, …, argn)` is equivalent to `std::println(“{} {} … {}”, arg1, arg2, …, argn)`
 
-- Implements: [Proposal of `std::dump` (P2879R0)](https://wg21.link/P2879R0)
+Implements: [Proposal of `std::dump` (P2879R0)](https://wg21.link/P2879R0)
+
+**Status**: [Dropped. Never got completed.](https://github.com/bemanproject/beman/blob/f5eedad83c135d9ecff22f465e99800b5965d2ce/docs/BEMAN_LIBRAY_MATURITY_MODEL.md#dropped-never-got-completed).
 
 ## Building beman.dump
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A call to `beman::dump::dump(arg1, arg2, …, argn)` is equivalent to `std::prin
 
 Implements: [Proposal of `std::dump` (P2879R0)](https://wg21.link/P2879R0)
 
-**Status**: [Retired. No longer maintained or actively developed.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#retired-no-longer-maintained-or-actively-developed).
+**Status**: [Retired. No longer maintained or actively developed.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#retired-no-longer-maintained-or-actively-developed)
 
 ## Building beman.dump
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # beman.dump: A tool for dumping an object's value to standard output
 
-<img src="https://github.com/bemanproject/beman/blob/f5eedad83c135d9ecff22f465e99800b5965d2ce/docs/img/logo-beman-library-dropped.png" style="width:5%; height:auto;">  ![Continuous Integration Tests](https://github.com/bemanproject/dump/actions/workflows/ci_tests.yml/badge.svg)
+<img src="https://github.com/bemanproject/beman/blob/main/images/logos/beman_logo-beman_library_retired.png" style="width:5%; height:auto;">  ![Continuous Integration Tests](https://github.com/bemanproject/dump/actions/workflows/ci_tests.yml/badge.svg)
 
 `beman::dump::dump()` prints its arguments space-separated with a new-line. This
 is useful as a debugging utility.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A call to `beman::dump::dump(arg1, arg2, …, argn)` is equivalent to `std::prin
 
 Implements: [Proposal of `std::dump` (P2879R0)](https://wg21.link/P2879R0)
 
-**Status**: [Dropped. Never got completed.](https://github.com/bemanproject/beman/blob/f5eedad83c135d9ecff22f465e99800b5965d2ce/docs/BEMAN_LIBRAY_MATURITY_MODEL.md#dropped-never-got-completed).
+**Status**: [Retired. No longer maintained or actively developed.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#retired-no-longer-maintained-or-actively-developed).
 
 ## Building beman.dump
 


### PR DESCRIPTION
Official dump for beman.dump - #5 

Note: WIP PR, need to wait for https://github.com/bemanproject/beman/pull/72 to be merged, and then I will replace $commit from current used URL with "main" before merge. 
Currently, this PR is a PoC of how we can use changes proposed in https://github.com/bemanproject/beman/pull/72. 

Expected visual README:
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/72e49313-f946-4f60-823d-cba4629600ff" />
